### PR TITLE
FIX for SVG support

### DIFF
--- a/src/angular-swipe.js
+++ b/src/angular-swipe.js
@@ -149,8 +149,9 @@
 
         swipe.bind(element, {
           'start': function(coords, event) {
-            if (axis && (! event.target.className || event.target.className &&
-              event.target.className.match('noPreventDefault') === null)) {
+            var className = event.target.getAttribute('class');
+            if (axis && (! className || className &&
+              className.match('noPreventDefault') === null)) {
                 event.preventDefault();
             }
             startCoords = coords;


### PR DESCRIPTION
SVG.clasName is not a string but an object. The function `match` is not defined. To avoid this issue, I suggest to use the `getAttribute` function